### PR TITLE
Enable private docs

### DIFF
--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -185,8 +185,15 @@ Private Documentation
 =====================
 This extension can be used with private Read the Docs pages by setting the environment
 variable ``READTHEDOCS_TOKEN``. This token is only used when building projects that are
-marked with ``is_subproject``.
+marked with ``is_subproject``. To get a token:
 
+#. Navigate to the admin page for the **main** project.
+#. Click "Sharing".
+#. Click "New Share".
+#. Choose "HTTP Header Token" for the "Access Type".
+#. Optionally set the expiration date and description.
+#. Click "Save".
+#. Copy the token.
 
 Creating links between the projects
 ===================================

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -181,6 +181,12 @@ yourself before building the documentation. The ``READTHEDOCS_LANGUAGE`` and ``R
 will default to ``en`` and ``latest``. To prevent you from doing this manually, you can add
 them to the Make files that are automatically created by ``sphinx-quickstart``.
 
+Private Documentation
+=====================
+This extension can be used with private Read the Docs pages by setting the environment
+variable ``READTHEDOCS_TOKEN``. This token is only used when building projects that are
+marked with ``is_subproject``.
+
 
 Creating links between the projects
 ===================================

--- a/subprojecttoctree/__init__.py
+++ b/subprojecttoctree/__init__.py
@@ -102,7 +102,13 @@ def add_master_file(app, config):
         toctree_source_url = (
             f"{master_url}/{language}/" f"{version}/_sources/index.rst.txt"
         )
-        response = requests.get(toctree_source_url)
+
+        headers = None
+        readthedocs_token = os.environ.get("READTHEDOCS_TOKEN")
+        if readthedocs_token:
+            headers = {"Authorization": f"Bearer {readthedocs_token}"}
+
+        response = requests.get(toctree_source_url, headers=headers)
         response.raise_for_status()
         data = response.text
         with (src_dir / "master__.rst").open("w") as open_masterdoc:

--- a/subprojecttoctree/__init__.py
+++ b/subprojecttoctree/__init__.py
@@ -60,10 +60,7 @@ def add_master_toctree_to_index(app, doctree):
                 # index entries when the subproject is found in the master index
                 new_entries.extend(toctree.attributes["entries"])
 
-                # also store the last master index entry,
-                # so that we can use it to generate the previous
                 if last_master_entry:
-                    app.env.last_master_entry = last_master_entry
                     last_entry_title = nodes.title()
                     last_entry_title += nodes.Text(title)
                     app.env.titles[last_master_entry] = last_entry_title
@@ -75,10 +72,13 @@ def add_master_toctree_to_index(app, doctree):
                 new_entry = (
                     f"{master_readthedocs_url}/{language}/{version}/{entry}.html"
                 )
-                # TODO: Change to new_entries.append((entry, new_entry))
-                new_entries.append((title, new_entry))
+                new_entries.append((entry, new_entry))
                 toctree.attributes["includefiles"].append(new_entry)
                 last_master_entry = new_entry
+
+                # also store the last master index entry,
+                # so that we can use it to generate the previous
+                app.env.last_master_entry = last_master_entry
         toctree.attributes["entries"] = new_entries
         env_toctree = list(app.env.tocs["index"].findall(ToctreeNode))[0]
         env_toctree["entries"] = new_entries
@@ -106,7 +106,7 @@ def add_master_file(app, config):
         headers = None
         readthedocs_token = os.environ.get("READTHEDOCS_TOKEN")
         if readthedocs_token:
-            headers = {"Authorization": f"Bearer {readthedocs_token}"}
+            headers = {"Authorization": f"Token {readthedocs_token}"}
 
         response = requests.get(toctree_source_url, headers=headers)
         response.raise_for_status()


### PR DESCRIPTION
After setting this up and building it locally, I realized it doesn't work very well with the format of our docs, so I didn't end up testing it for remote builds on ReadTheDocs. It did work for local builds though. 

I thought i might as well submit the PR, in case you want it. but feel free to close as well.